### PR TITLE
Fix Script.collectAndRun -> FSI.collectAndRun

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,13 @@ let ``a unit test`` = test {
 }
 
 // collect test from Assembly and run tests
+// ===== case ( FSharp Interactive ) =====
 new ScriptContext()
 |> FSI.collectAndRun( fun _ -> Assembly.GetExecutingAssembly() )
+
+// ===== case ( Othres ) =====
+new ScriptContext()
+|> Script.collectAndRun( fun _ -> Assembly.GetExecutingAssembly() )
 ```
 
 If you want to use your reporter:

--- a/README.md
+++ b/README.md
@@ -12,16 +12,18 @@ Persimmon.Script is a script helper for Persimmon.
 #r @"./packages/Persimmon.Runner/lib/net40/Persimmon.Runner.dll"
 #r @"./packages/Persimmon.Script/net45/Persimmon.Script.dll"
 
-open System.IO
+open UseTestNameByReflection
 open System.Reflection
 open Persimmon
 
 // write tests ...
+let ``a unit test`` = test {
+  do! assertEquals 1 2
+}
 
 // collect test from Assembly and run tests
-use context = new ScriptContext()
-context
-|> Script.collectAndRun (fun _ -> Assembly.GetExecutingAssembly())
+new ScriptContext()
+|> FSI.collectAndRun( fun _ -> Assembly.GetExecutingAssembly() )
 ```
 
 If you want to use your reporter:


### PR DESCRIPTION
`Fsi ( fsharpi )`コマンドで実行するときと `REPL`内で実行する場合と２通りあるため、`FSI.collectAndRun`コマンドの方が例には適してると思いましたのでプルリクします。

```
// この場合は問題ない
$ fsharpi foo.fsx

// この場合は`FSI.collectAndRun`でないと履歴が出力されて見づらくなる
$ fsharpi
> #load "foo.fsx"
```